### PR TITLE
Rewrote the downloading methods to deal with download links that don't

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.13 (/usr/bin/python2.7)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7 (venv-pi_romulus)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/pi_romulus.iml
+++ b/.idea/pi_romulus.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 2.7 (venv-pi_romulus)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/romulus.py
+++ b/romulus.py
@@ -10,6 +10,10 @@ from forms import SearchForm
 
 __author__ = 'arthur'
 
+# Switch to True for debugging. Set settings in PyCharm
+# to handle remote debugging on localhost port 5678
+DEBUG = True
+
 
 class App(npyscreen.NPSAppManaged):
     """
@@ -26,6 +30,9 @@ class App(npyscreen.NPSAppManaged):
         """
         Initialize the forms.
         """
+        if DEBUG:
+            import pydevd
+            pydevd.settrace('localhost', port=5678, stdoutToServer=True, stderrToServer=True)
         self.addForm('MAIN', SearchForm, name="Search for ROM")
 
 


### PR DESCRIPTION
follow the normal routine and include extra redirects. This was expecially the case with Dreamcast games.
The download links that include redirects are now looped over until they reach the final download link.
May need to include a limit to redirects.